### PR TITLE
Modified access-control-allow-origin header

### DIFF
--- a/app.py
+++ b/app.py
@@ -127,6 +127,7 @@ def set_response_headers(response):
     response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
     response.headers['Pragma'] = 'no-cache'
     response.headers['Expires'] = '0'
+    response.headers['Access-Control-Allow-Origin'] = '*'
     return response
 
 if __name__ == '__main__':


### PR DESCRIPTION
This modifies the response header from default value `null` to `*`. This would allow other websites to send API requests.